### PR TITLE
chore: decrease the multipart threshold

### DIFF
--- a/src/lib/upload-file.ts
+++ b/src/lib/upload-file.ts
@@ -7,10 +7,10 @@ import { toFile } from '../internal/to-file';
 import { multipartFormRequestOptions } from '../internal/uploads';
 import type { Fetch } from '../internal/builtin-types';
 
-const DEFAULT_THRESHOLD = 100 * 1024 * 1024; // 100MB
+const DEFAULT_THRESHOLD = 10 * 1024 * 1024; // 10MB
 const DEFAULT_CONCURRENCY = 5;
 const DEFAULT_PART_SIZE = 100 * 1024 * 1024; // 100MB per part
-const MIN_PART_SIZE = 5 * 1024 * 1024; // 5MB minimum
+const MIN_PART_SIZE = 1 * 1024 * 1024; // 1MB minimum
 const MAX_PART_COUNT = 10_000;
 
 export interface PartUploadEvent {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes upload behavior by triggering multipart uploads more often and allowing smaller parts, which can increase request count and surface edge cases in client/server upload handling.
> 
> **Overview**
> **Multipart uploads are now used for smaller files by default** by dropping `DEFAULT_THRESHOLD` from 100MB to 10MB.
> 
> It also **lowers the minimum allowed `partSize`/`threshold`** by changing `MIN_PART_SIZE` from 5MB to 1MB, allowing more (and smaller) parts per upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 575bb7dee75b6b0fb17740260b14e9477a2b7f66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->